### PR TITLE
updateExistingVariableWithoutPrefix

### DIFF
--- a/core/src/main/java/com/seleniumtests/core/SeleniumTestsContext.java
+++ b/core/src/main/java/com/seleniumtests/core/SeleniumTestsContext.java
@@ -1762,6 +1762,10 @@ public class SeleniumTestsContext {
     public SeleniumRobotVariableServerConnector getVariableServer() {
 		return variableServer;
 	}
+
+    public void setVariableServer(SeleniumRobotVariableServerConnector variableServer) {
+        this.variableServer = variableServer;
+    }
     
     public List<SeleniumGridConnector> getSeleniumGridConnectors() {
     	if (seleniumGridConnectors == null) {


### PR DESCRIPTION
issue while we update a variable without a prefix it create one but method createOrUpdateVariable() works well